### PR TITLE
Don't use "null" for `Access-Control-Allow-Origin`

### DIFF
--- a/lib/sinatra/cors.rb
+++ b/lib/sinatra/cors.rb
@@ -5,6 +5,11 @@ module Sinatra
     module Helpers
       def cors
         if is_cors_request?
+          unless origin_is_allowed?
+            logger.warn bad_origin_message
+            return
+          end
+
           if is_preflight_request?
             unless method_is_allowed?
               logger.warn bad_method_message
@@ -23,12 +28,7 @@ module Sinatra
             response.headers["Access-Control-Expose-Headers"] = settings.expose_headers if settings.expose_headers?
           end
 
-          if origin_is_allowed?
-            response.headers["Access-Control-Allow-Origin"] = request.env["HTTP_ORIGIN"]
-          else
-            logger.warn bad_origin_message
-            response.headers["Access-Control-Allow-Origin"] = "null"
-          end
+          response.headers["Access-Control-Allow-Origin"] = request.env["HTTP_ORIGIN"]
           response.headers["Access-Control-Allow-Credentials"] = settings.allow_credentials.to_s if settings.allow_credentials?
         end
       end

--- a/spec/cors_spec.rb
+++ b/spec/cors_spec.rb
@@ -39,11 +39,7 @@ RSpec.describe "Sinatra.Cors" do
     end
 
     it "should not return an Access-Control-Allow-Origin header" do
-      expect(last_response["Access-Control-Allow-Origin"]).to be(nil)
-    end
-
-    it "should not return an Access-Control-Allow-Methods header" do
-      expect(last_response["Access-Control-Allow-Methods"]).to be(nil)
+      assert_no_access_control_headers
     end
   end
 
@@ -143,12 +139,12 @@ RSpec.describe "Sinatra.Cors" do
 
     it "should have no access control headers if the origin is not allowed" do
       make_request("http://bar.com")
-      expect(last_response["Access-Control-Allow-Origin"]).to eq(nil)
+      assert_no_access_control_headers
     end
 
     it "should have no access control headers if none of the origins are not allowed" do
       make_request("http://foo.com http://bar.com")
-      expect(last_response["Access-Control-Allow-Origin"]).to eq(nil)
+      assert_no_access_control_headers
     end
 
     it "should allow any origin if :allowed_origin is '*'" do
@@ -187,5 +183,14 @@ RSpec.describe "Sinatra.Cors" do
 
       expect(last_response["Access-Control-Expose-Headers"]).to eq("location,link")
     end
+  end
+
+  def assert_no_access_control_headers
+      expect(last_response["Access-Control-Allow-Origin"]).to eq(nil)
+      expect(last_response["Access-Control-Allow-Header"]).to eq(nil)
+      expect(last_response["Access-Control-Allow-Methods"]).to eq(nil)
+      expect(last_response["Access-Control-Max-Age"]).to eq(nil)
+      expect(last_response["Access-Control-Expose-Headers"]).to eq(nil)
+      expect(last_response["Access-Control-Allow-Credentials"]).to eq(nil)
   end
 end

--- a/spec/cors_spec.rb
+++ b/spec/cors_spec.rb
@@ -141,14 +141,14 @@ RSpec.describe "Sinatra.Cors" do
       get "/foo/1", {}, rack_env
     end
 
-    it "should be 'null' if the origin is not allowed" do
+    it "should have no access control headers if the origin is not allowed" do
       make_request("http://bar.com")
-      expect(last_response["Access-Control-Allow-Origin"]).to eq("null")
+      expect(last_response["Access-Control-Allow-Origin"]).to eq(nil)
     end
 
-    it "should be 'null' if none of the origins are not allowed" do
+    it "should have no access control headers if none of the origins are not allowed" do
       make_request("http://foo.com http://bar.com")
-      expect(last_response["Access-Control-Allow-Origin"]).to eq("null")
+      expect(last_response["Access-Control-Allow-Origin"]).to eq(nil)
     end
 
     it "should allow any origin if :allowed_origin is '*'" do


### PR DESCRIPTION
Should we test that the other headers are not set as well? The spec seemed to just say "don't use null" not necessarily what to use instead?